### PR TITLE
added sorting to release branches list

### DIFF
--- a/source/_templates/versions.html
+++ b/source/_templates/versions.html
@@ -17,7 +17,7 @@
 	  {% if versions %}
 	  <h3>{{ _('Releases') }}</h3>
       <ul>
-        {%- for item in versions.releases %}
+        {%- for item in versions.releases|sort(attribute='name', reverse = True) %}
         <li><a href="{{ item.url }}">{{ item.name }}</a></li>
         {%- endfor %}
       </ul>

--- a/source/conf.py
+++ b/source/conf.py
@@ -27,6 +27,7 @@ copyright = '2021, CBIIT'
 author = 'CBIIT'
 release = "release-3.8.0"
 version = "release-3.8.0"
+smv_latest_version = 'release-3.8.0'
 
 # -- General configuration ---------------------------------------------------
 
@@ -116,7 +117,7 @@ smv_remote_whitelist = None
 # has been released or if it’s a development version. To allow more 
 # flexibility, the regex is evaluated over the full refname.
 smv_released_pattern = r'.*release.*'
-smv_latest_version = 'master'
+#smv_latest_version = 'master'
 
 # AutoStructify - for advanced markdown to rst transformations
 # Needs to be at the bottom of conf.py


### PR DESCRIPTION
added sorting for the released versions list. This will sort the versions by name in reverse order, which will make the latest versions of the docs show up at the top of the list. This also updates the 'smv_latest_version' variable in conf.py to the latest version of the code so that is set as 'Latest'